### PR TITLE
Update abbr.zsh-theme

### DIFF
--- a/abbr.zsh-theme
+++ b/abbr.zsh-theme
@@ -72,6 +72,7 @@ _abbr_section_logon () {
 _abbr_section_pwd () {
   local p="$(print -nP '%/')"
   local o=""
+  local d=""
 
   if [[ $p == / ]]; then
     o+='/'


### PR DESCRIPTION
Set local variable d. When using tmux for some reason initial value of d is "GNOME" on my machine.
![image](https://user-images.githubusercontent.com/578776/53827889-beeae500-3f41-11e9-863b-712d4b039539.png)
